### PR TITLE
Covering with tests edge cases with SOC

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -412,12 +412,14 @@ class SLXChgCtrlUpdateCoordinator(DataUpdateCoordinator):
     def callback_charger_plug_connected(self, event: Event) -> None:
         value = self.extract_bool_state(event.data["new_state"])
         _LOGGER.info("Callback - charger plug connected %s", value)
-        self.charging_manager.plug_status = value
-        ## Getting session energy at the moment when plug is connected.
-        if self.evse is not None:
-            energy = self.evse.get_session_energy()
-            if energy is not None:
-                self.charging_manager.add_charger_energy(energy)
+        if value is True:
+            # Try to get session energy at the moment when plug is connected.
+            evse_energy: float = None
+            if self.evse is not None:
+                evse_energy = self.evse.get_session_energy()
+            self.charging_manager.plug_connected(evse_energy)
+        else:
+            self.charging_manager.plug_disconnected()
 
     @callback
     def callback_soc_level(self, event: Event) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,56 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
+import logging
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+from homeassistant.const import (
+    CONF_SCAN_INTERVAL,
+)
+
+from custom_components.slxchargingcontroller.const import (
+    DEFAULT_SCAN_INTERVAL,
+    CONF_CHARGER_TYPE,
+    CONF_EVSE_SESSION_ENERGY,
+    CONF_EVSE_PLUG_CONNECTED,
+    CONF_CAR_TYPE,
+    CONF_CAR_SOC_LEVEL,
+    CONF_CAR_SOC_UPDATE_TIME,
+    CONF_BATTERY_CAPACITY,
+    DOMAIN,
+    ENT_CHARGE_MODE,
+    ENT_CHARGE_METHOD,
+    CHR_MODE_UNKNOWN,
+    CHR_METHOD_ECO,
+    CHR_METHOD_MANUAL,
+    ENT_SOC_LIMIT_MIN,
+    ENT_SOC_LIMIT_MAX,
+    ENT_SOC_TARGET,
+    CHARGER_MODES,
+)
+
+FIXTURE__DEFAULT_CONFIG_ENTRY = {
+    "entry_id": "1",
+    "domain": DOMAIN,
+    "title": "testinstance_slxchargingcontroller",
+    "options": {
+        CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+        CONF_CAR_TYPE: "manual",
+        CONF_CAR_SOC_LEVEL: "test.entity_soc",
+        #        CONF_CAR_SOC_UPDATE_TIME: "",
+        CONF_CHARGER_TYPE: "manual",
+        CONF_EVSE_SESSION_ENERGY: "evsetest.energy",
+        CONF_EVSE_PLUG_CONNECTED: "evsetest.plug",
+    },
+    #    "source": config_entries.SOURCE_USER,
+    "unique_id": f"{DOMAIN}-fdew",
+}
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # This fixture enables loading custom integrations in all tests.
@@ -14,3 +62,35 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integration tests."""
     yield
+
+
+# registering customer marker
+def pytest_configure(config):
+    config.addinivalue_line("markers", "fixt_data")
+
+
+@pytest.fixture
+def coordinator_factory(hass: HomeAssistant, request):
+    marker = request.node.get_closest_marker("fixt_data")
+    if marker is None:
+        yield creation_of_coordinator(hass)
+    else:
+        params = marker.args[0]
+        yield creation_of_coordinator(hass, params)
+
+
+async def creation_of_coordinator(hass, params: any = None):
+    if params is None:
+        config_entry = MockConfigEntry(**FIXTURE__DEFAULT_CONFIG_ENTRY)
+    else:
+        tmp_config = FIXTURE__DEFAULT_CONFIG_ENTRY
+        _LOGGER.warning(params)
+        for k, v in params.items():
+            tmp_config["options"][k] = v
+        _LOGGER.error(tmp_config)
+        config_entry = MockConfigEntry(**tmp_config)
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator_intance = hass.data[config_entry.domain][config_entry.unique_id]
+    return coordinator_intance

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -118,14 +118,6 @@ async def test_create_coordinator_fixture(
     assert coordinator_instance.evse._session_energy_name == "evsetest.energy"
 
 
-# this is how I can overwrite the default configuration settings
-@pytest.mark.fixt_data({CONF_EVSE_SESSION_ENERGY: "point_evse"})
-async def test_alternative_fixture(hass: HomeAssistant, coordinator_factory) -> None:
-    coordinator_instance: SLXChgCtrlUpdateCoordinator = await coordinator_factory
-    assert coordinator_instance.charging_manager is not None
-    assert coordinator_instance.evse._session_energy_name == "point_evse"
-
-
 # scenarios to be tested in coordinator.
 # Functional tests
 # - requesting soc update and correctly handling it's retry, timeout
@@ -176,11 +168,12 @@ async def test_soc_request_after_plugged(
 
 
 async def test_no_soc_request_after_plugged(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory, caplog
 ) -> None:
     """Tests if car is not asked for SOC update after plug is being connected - when SOC is "fresh" enough"""
 
     coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
+    # caplog.set_level(logging.debug)
     _LOGGER.info(coordinator.car_config)
     _LOGGER.info(coordinator)
     assert coordinator is not None
@@ -236,3 +229,14 @@ async def test__template(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
 ) -> None:
     coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
+
+
+## TODO - for some reason this fixt_data is remaining as active impacting any further tests. As workaround temporary moved as the last test.
+
+
+# this is how I can overwrite the default configuration settings
+@pytest.mark.fixt_data({CONF_EVSE_SESSION_ENERGY: "point_evse"})
+async def test_alternative_fixture(hass: HomeAssistant, coordinator_factory) -> None:
+    coordinator_instance: SLXChgCtrlUpdateCoordinator = await coordinator_factory
+    assert coordinator_instance.charging_manager is not None
+    assert coordinator_instance.evse._session_energy_name == "point_evse"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,7 +12,10 @@ from custom_components.slxchargingcontroller.coordinator import (
     SLXChgCtrlUpdateCoordinator,
 )
 
-from custom_components.slxchargingcontroller.const import CONF_EVSE_SESSION_ENERGY
+from custom_components.slxchargingcontroller.const import (
+    CONF_EVSE_SESSION_ENERGY,
+    CONF_EVSE_PLUG_CONNECTED,
+)
 import homeassistant.util.dt as dt_util
 from datetime import datetime, timedelta
 from freezegun.api import FrozenDateTimeFactory
@@ -46,27 +49,16 @@ async def test_hass_exists(hass: HomeAssistant) -> None:
     assert hass is not None
 
 
-async def test_create_coordinator(hass: HomeAssistant) -> None:
-    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
-
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+async def test_create_coordinator(hass: HomeAssistant, coordinator_factory) -> None:
+    coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
 
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
 
 
 async def test_connect_and_soc_entity(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
 ) -> None:
-    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
-
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-    coordinator: SLXChgCtrlUpdateCoordinator = hass.data[config_entry.domain][
-        config_entry.unique_id
-    ]
+    coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
     _LOGGER.info(coordinator.car_config)
     _LOGGER.info(coordinator)
     assert coordinator is not None
@@ -90,16 +82,9 @@ async def test_connect_and_soc_entity(
 
 
 async def test_coordinator_soc_timeout(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
 ) -> None:
-    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
-
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-    coordinator: SLXChgCtrlUpdateCoordinator = hass.data[config_entry.domain][
-        config_entry.unique_id
-    ]
+    coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
     _LOGGER.info(coordinator.car_config)
     _LOGGER.info(coordinator)
     assert coordinator is not None
@@ -139,3 +124,115 @@ async def test_alternative_fixture(hass: HomeAssistant, coordinator_factory) -> 
     coordinator_instance: SLXChgCtrlUpdateCoordinator = await coordinator_factory
     assert coordinator_instance.charging_manager is not None
     assert coordinator_instance.evse._session_energy_name == "point_evse"
+
+
+# scenarios to be tested in coordinator.
+# Functional tests
+# - requesting soc update and correctly handling it's retry, timeout
+# -
+
+# Group 1 - car with SOC read immediatelly (no soc update defined)
+# do we ge soc request after plug-in.
+# immediatelly soc estimate after reading soc energy (no delay)
+# are we getting re-try of soc request if it was not provided within timeout
+#
+
+
+async def helper_set_entity_value(
+    hass: HomeAssistant, entity_name: str, entity_value: str
+):
+    await hass.async_add_executor_job(
+        hass.states.set,
+        entity_name,
+        entity_value,
+        {},
+    )
+
+
+async def test_soc_request_after_plugged(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
+) -> None:
+    """Tests if car is asked for SOC update after plug is being connected"""
+    coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
+    _LOGGER.info(coordinator.car_config)
+    _LOGGER.info(coordinator)
+    assert coordinator is not None
+    # soc_timeout = coordinator.car_config[SLXCar.CONF_SOC_REQUEST_TIMEOUT]
+
+    with patch(
+        "custom_components.slxchargingcontroller.slxcarmanual.SLXCarManual.request_soc_update",
+        return_value=True,
+    ) as car_mock:
+        entity_name_evse_plug: str = FIXTURE_CONFIG_ENTRY["options"][
+            CONF_EVSE_PLUG_CONNECTED
+        ]
+        await helper_set_entity_value(hass, entity_name_evse_plug, "on")
+
+        assert (
+            coordinator.charging_manager._car_connected_status
+            == CarConnectedStates.ramping_up
+        )
+        assert len(car_mock.mock_calls) == 1
+
+
+async def test_no_soc_request_after_plugged(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
+) -> None:
+    """Tests if car is not asked for SOC update after plug is being connected - when SOC is "fresh" enough"""
+
+    coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory
+    _LOGGER.info(coordinator.car_config)
+    _LOGGER.info(coordinator)
+    assert coordinator is not None
+    soc_before_energy = coordinator.car_config[SLXCar.CONF_SOC_BEFORE_ENERGY]
+
+    # Set SOC
+    entity_name_soc: str = FIXTURE_CONFIG_ENTRY["options"][CONF_CAR_SOC_LEVEL]
+    await helper_set_entity_value(hass, entity_name_soc, "30")
+
+    freezer.tick(timedelta(seconds=(soc_before_energy - 10)))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        coordinator.charging_manager._attr_bat_soc_estimated is None
+    ), "before energy was passed from the charged (and plug is connected), estimated soc should still be unknown"
+
+    entity_name_evse_energy: str = FIXTURE_CONFIG_ENTRY["options"][
+        CONF_EVSE_SESSION_ENERGY
+    ]
+    _LOGGER.warning(entity_name_evse_energy)
+    await helper_set_entity_value(hass, entity_name_evse_energy, "1")
+
+    with patch(
+        "custom_components.slxchargingcontroller.slxcarmanual.SLXCarManual.request_soc_update",
+        return_value=True,
+    ) as car_mock:
+        entity_name_evse_plug: str = FIXTURE_CONFIG_ENTRY["options"][
+            CONF_EVSE_PLUG_CONNECTED
+        ]
+
+        assert (
+            coordinator.charging_manager._car_connected_status is None
+        ), "before connecting the plug, status should still be None"
+
+        assert (
+            coordinator.charging_manager._attr_bat_soc_estimated is None
+        ), "before connecting plug, estimated soc should still be unknown"
+
+        await helper_set_entity_value(hass, entity_name_evse_plug, "on")
+
+        assert (
+            coordinator.charging_manager._car_connected_status
+            == CarConnectedStates.soc_known
+        )
+
+        assert len(car_mock.mock_calls) == 0
+
+        assert coordinator.charging_manager._attr_bat_soc_estimated == 30
+
+
+async def test__template(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, coordinator_factory
+) -> None:
+    coordinator: SLXChgCtrlUpdateCoordinator = await coordinator_factory

--- a/tests/test_energy_tracker.py
+++ b/tests/test_energy_tracker.py
@@ -17,6 +17,7 @@ def test_energy_tracker_timemachine():
     with freeze_time("Jan 1, 2023") as frozen_datetime:
         energy_tracker = SlxEnergyTracker(soc_before_energy=300, soc_after_energy=200)
         can_calculate: bool = False
+        energy_tracker.connect_plug()
         can_calculate = energy_tracker.add_entry(10)
         frozen_datetime.tick(delta=timedelta(seconds=10))
         assert can_calculate is False
@@ -35,11 +36,10 @@ def test_energy_tracker_soc_before():
     with freeze_time("Jan 1, 2023") as frozen_datetime:
         energy_tracker = SlxEnergyTracker(soc_before_energy=300, soc_after_energy=200)
         can_calculate: bool = False
-
         energy_tracker.update_soc(dt_util.utcnow(), 50)
 
         frozen_datetime.tick(delta=timedelta(seconds=290))
-
+        energy_tracker.connect_plug()
         can_calculate = energy_tracker.add_entry(10)
         assert can_calculate is True
 
@@ -52,11 +52,9 @@ def test_energy_tracker_soc_before_fail():
     with freeze_time("Jan 1, 2023") as frozen_datetime:
         energy_tracker = SlxEnergyTracker(soc_before_energy=300, soc_after_energy=200)
         can_calculate: bool = False
-
         energy_tracker.update_soc(dt_util.utcnow(), 50)
-
         frozen_datetime.tick(delta=timedelta(seconds=310))
-
+        energy_tracker.connect_plug()
         can_calculate = energy_tracker.add_entry(10)
         assert can_calculate is False
 
@@ -70,6 +68,7 @@ def test_energy_tracker_soc_after():
         energy_tracker = SlxEnergyTracker(soc_before_energy=300, soc_after_energy=200)
         can_calculate: bool = False
 
+        energy_tracker.connect_plug()
         can_calculate = energy_tracker.add_entry(10)
         assert can_calculate is False
 
@@ -87,7 +86,7 @@ def test_energy_tracker_soc_fail():
     with freeze_time("Jan 1, 2023") as frozen_datetime:
         energy_tracker = SlxEnergyTracker(soc_before_energy=300, soc_after_energy=200)
         can_calculate: bool = False
-
+        energy_tracker.connect_plug()
         can_calculate = energy_tracker.add_entry(10)
         assert can_calculate is False
 


### PR DESCRIPTION
This also includes change in SlxEnergyTracker to keep information about plug status. This allows checking if SOC requires refreshing when plug is connected. 